### PR TITLE
Moved desserts & adjectives options into separate files

### DIFF
--- a/data/adjectives.js
+++ b/data/adjectives.js
@@ -1,0 +1,14 @@
+exports.adjectives = [
+  'bbq',
+  'berrylicious',
+  'butterscotch',
+  'caramel',
+  'cheesy',
+  'chocolate',
+  'salted egg',
+  'salty',
+  'smoked',
+  'strawberry',
+  'sugar',
+  'sweet'
+]

--- a/data/desserts.js
+++ b/data/desserts.js
@@ -1,0 +1,22 @@
+exports.desserts = [
+  'ais kacang',
+  'akok',
+  'apple crumble',
+  'brownies',
+  'buchty',
+  'cake',
+  'cekodok',
+  'cempedak creme',
+  'cempedak fritters',
+  'cendol',
+  'chocolate',
+  'cupcake',
+  'eclair',
+  'frgál',
+  'kek lapis',
+  'krapfen',
+  'kremrole',
+  'muffin',
+  'tart',
+  'větrník'
+]

--- a/index.js
+++ b/index.js
@@ -1,14 +1,13 @@
-const utils = require('./helpers/utils')
-
-const desserts = ['ais kacang', 'akok', 'apple crumble', 'brownies', 'buchty', 'cake', 'cekodok', 'cempedak creme', 'cempedak fritters', 'cendol', 'chocolate', 'cupcake', 'eclair', 'frgál', 'kek lapis', 'krapfen', 'kremrole', 'muffin', 'tart', 'větrník']
-const adjectives = ['bbq', 'berrylicious', 'butterscotch', 'caramel', 'cheesy', 'chocolate', 'salted egg', 'salty', 'smoked', 'strawberry', 'sugar', 'sweet']
+const { getRandomIndex } = require('./helpers/utils')
+const { adjectives } = require('./data/adjectives')
+const { desserts } = require('./data/desserts')
 
 /**
  * Generate a dessert.
  * @return {string} A random dessert name
  */
 function generateDessert () {
-  const dessertIndex = utils.getRandomIndex(desserts)
+  const dessertIndex = getRandomIndex(desserts)
   return desserts[dessertIndex]
 }
 
@@ -17,8 +16,8 @@ function generateDessert () {
  * @return {string} A random dessert name with an adjective
  */
 function generateYummyDessert () {
-  const dessertIndex = utils.getRandomIndex(desserts)
-  const adjectiveIndex = utils.getRandomIndex(adjectives)
+  const dessertIndex = getRandomIndex(desserts)
+  const adjectiveIndex = getRandomIndex(adjectives)
   return `${adjectives[adjectiveIndex]} ${desserts[dessertIndex]}`
 }
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Generates random dessert names from a precompiled list in code. No database is used.",
   "main": "index.js",
   "scripts": {
+    "standard": "standard --fix",
     "test": "standard && mocha --recursive"
   },
   "keywords": [


### PR DESCRIPTION
**what has changed?**
Moved desserts and adjectives options array into each separate file located under the data directory. Other than, added script cmd to run `standard --fix`

REFERENCES: 
[ISSUE 23](https://github.com/sanijalal/random-dessert-generator/issues/23)
[ISSUE 24](https://github.com/sanijalal/random-dessert-generator/issues/24)